### PR TITLE
Use deepEqual for compare arrays

### DIFF
--- a/editor/initial_code/js_node
+++ b/editor/initial_code/js_node
@@ -7,9 +7,9 @@ function flatList(array){
 var assert = require('assert');
 
 if (!global.is_checking) {
-    assert.equal(flatList([1, 2, 3]), [1, 2, 3], "First");
-    assert.equal(flatList([1, [2, 2, 2], 4]), [1, 2, 2, 2, 4], "Second");
-    assert.equal(flatList([[[2]], [4, [5, 6, [6], 6, 6, 6], 7]]), [2, 4, 5, 6, 6, 6, 6, 6, 7], "Third");
-    assert.equal(flatList([-1, [1, [-2], 1], -1]), [-1, 1, -2, 1, -1], "Four");
+    assert.deepEqual(flatList([1, 2, 3]), [1, 2, 3], "First");
+    assert.deepEqual(flatList([1, [2, 2, 2], 4]), [1, 2, 2, 2, 4], "Second");
+    assert.deepEqual(flatList([[[2]], [4, [5, 6, [6], 6, 6, 6], 7]]), [2, 4, 5, 6, 6, 6, 6, 6, 7], "Third");
+    assert.deepEqual(flatList([-1, [1, [-2], 1], -1]), [-1, 1, -2, 1, -1], "Four");
     console.log("Coding complete? Click 'Check' to review your tests and earn cool rewards!");
 }


### PR DESCRIPTION
You must use deepEqual to compare arrays. Otherwise, node compares by reference, which is incorrect.